### PR TITLE
Create T1114.json

### DIFF
--- a/data/techniques/T1114.json
+++ b/data/techniques/T1114.json
@@ -1,0 +1,12 @@
+{
+    "id": "T1114",
+    "name": "Memory Acquisition via Cold Boot Attack",
+    "description": "Extracting volatile memory (RAM) from a powered-off system by quickly rebooting or transferring the memory module to another system before residual data fades. Cooling the memory modules can significantly slow down data decay, preserving critical data such as encryption keys or passwords.",
+    "synonyms": ["Extracting RAM data using Cold Boot Attack"],
+    "details": "",
+    "subtechniques": [],
+    "examples":  ["An examiner freezes a computer’s RAM by spraying it with liquid nitrogen or even using inverted canned air, then powering off the live system without proper shutdown, and then booting into an external plugged USB, and try capturing the residual RAM content with encryption keys that might still be stored there."],
+    "weaknesses": ["W1032", "W1044"],
+    "CASE_output_classes" : [],
+    "references": ["https://www.sciencedirect.com/topics/computer-science/cold-boot-attack"], ["https://www.usenix.org/legacy/event/sec08/tech/full_papers/halderman/halderman.pdf"]
+}

--- a/data/techniques/T1114.json
+++ b/data/techniques/T1114.json
@@ -2,11 +2,11 @@
     "id": "T1114",
     "name": "Memory Acquisition via Cold Boot Attack",
     "description": "Extracting volatile memory (RAM) from a powered-off system by quickly rebooting or transferring the memory module to another system before residual data fades. Cooling the memory modules can significantly slow down data decay, preserving critical data such as encryption keys or passwords.",
-    "synonyms": ["Extracting RAM data using Cold Boot Attack"],
-    "details": "",
+    "synonyms": ["Cold Boot Attack", "Extracting RAM data using Cold Boot Attack"],
+    "details": "An examiner freezes a computer’s RAM by spraying it with liquid nitrogen or even using inverted canned air, then powering off the live system without proper shutdown, and then booting into an external plugged USB, and try capturing the residual RAM content with encryption keys that might still be stored there",
     "subtechniques": [],
-    "examples":  ["An examiner freezes a computer’s RAM by spraying it with liquid nitrogen or even using inverted canned air, then powering off the live system without proper shutdown, and then booting into an external plugged USB, and try capturing the residual RAM content with encryption keys that might still be stored there."],
-    "weaknesses": ["W1032", "W1044"],
-    "CASE_output_classes" : [],
-    "references": ["https://www.sciencedirect.com/topics/computer-science/cold-boot-attack"], ["https://www.usenix.org/legacy/event/sec08/tech/full_papers/halderman/halderman.pdf"]
+    "examples":  ["Using tool like Scraper"],
+    "weaknesses": ["W1032"],
+    "CASE_output_classes" : ["observable:Image"],
+    "references": ["Halderman, J.A., Schoen, S.D., Heninger, N., Clarkson, W., Paul, W., Calandrino, J.A., Feldman, A.J., Appelbaum, J. and Felten, E.W., 2009. Lest we remember: cold-boot attacks on encryption keys. Communications of the ACM, 52(5), pp.91-98."]
 }


### PR DESCRIPTION
Memory Acquisition via Cold Boot Attack Technique


Notes to consider:
- RAM has about maximum 10 minutes to have its content wiped out, as its content is gradually fading when powering off/rebooting
- Some freezing tools need to be utilized like liquid nitrogen spray to freeze the RAM
- Memory should not be encrypted at hardware level
- The forensic examiner must physically access the target device and its RAM modules.
- Such techniques might corrupt volatile memory.
- Such techniques are more towards legacy systems.
