### PR TITLE
Adds output path variation to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 /reporting_scripts/output
+/output


### PR DESCRIPTION
VS Code by default seems to put the output folder in the root of project so may be good to add that path in too.