### PR TITLE
Reworded and added link to M1067, updated M1066

### DIFF
--- a/data/mitigations/M1066.json
+++ b/data/mitigations/M1066.json
@@ -1,5 +1,5 @@
 {
     "id": "M1066",
-    "name": "Extract URLs from other areas of the disk",
+    "name": "Attempt to reconstruct browser activity from other areas of disk",
     "references" : ["Chivers, H., 2014. Private browsing: A window of forensic opportunity. Digital Investigation, 11(1), pp.20-29."]
 }

--- a/data/mitigations/M1067.json
+++ b/data/mitigations/M1067.json
@@ -1,5 +1,6 @@
 {
     "id": "M1067",
-    "name": "Extract URLs from a memory image",
+    "name": "Analyze web browser memory for web browsing activity",
+    "technique": "T1105",
     "references" : ["Chivers, H., 2014. Private browsing: A window of forensic opportunity. Digital Investigation, 11(1), pp.20-29."]
 }


### PR DESCRIPTION
Rewords the "Extract URLs from a memory image" in a mitigations in browser analysis to "Analyze web browser memory for web browsing activity", and directly links to T1105 (Memory examination (application-level)). 

Also rewords M1066 to "Attempt to reconstruct browser activity from other areas of disk"