### PR TITLE
Fix ID scanner to detect pre-migration ID formats

### DIFF
--- a/admin/id_assignment/assign_mitigation_id.py
+++ b/admin/id_assignment/assign_mitigation_id.py
@@ -47,10 +47,13 @@ def get_issue_comments(issue_number):
 
 
 def find_preview_comment(comments):
-    """Return the preview comment dict that contains the DFM-____ placeholder."""
+    """Return the preview comment dict that contains a mitigation ID placeholder.
+
+    Matches both new (DFM-____) and old (M____) placeholder formats.
+    """
     for comment in comments:
         body = comment.get("body", "")
-        if '"id": "DFM-____"' in body:
+        if '"id": "DFM-____"' in body or '"id": "M____"' in body:
             return comment
     return None
 
@@ -94,13 +97,19 @@ def main():
     old_body = preview["body"]
 
     # 3. Build revised JSON with real ID
+    #    Handle both new (DFM-____) and old (M____) placeholder formats
     revised_body = old_body.replace("DFM-____", mitigation_id)
+    revised_body = revised_body.replace("M____", mitigation_id)
     revised_body = revised_body.replace(
         "Thanks for proposing a new mitigation! Here's what it would look like as JSON:",
         "Your mitigation has been assigned an ID. Here is an updated copy of the JSON data with the ID completed:",
     )
     revised_body = revised_body.replace(
         "The mitigation ID (DFM-____) will be assigned during review.",
+        f"Mitigation ID **{mitigation_id}** has been assigned.",
+    )
+    revised_body = revised_body.replace(
+        "The mitigation ID (M____) will be assigned during review.",
         f"Mitigation ID **{mitigation_id}** has been assigned.",
     )
 

--- a/admin/id_assignment/assign_technique_id.py
+++ b/admin/id_assignment/assign_technique_id.py
@@ -57,14 +57,14 @@ def get_issue_comments(issue_number):
 
 
 def find_preview_comment(comments):
-    """Return the preview comment dict that contains the DFT-____ placeholder.
+    """Return the preview comment dict that contains a technique ID placeholder.
 
     The preview comment is posted by the technique-issue-preview workflow
-    and contains a JSON block with "id": "DFT-____".
+    and contains a JSON block with "id": "DFT-____" (or the old format "T____").
     """
     for comment in comments:
         body = comment.get("body", "")
-        if '"id": "DFT-____"' in body:
+        if '"id": "DFT-____"' in body or '"id": "T____"' in body:
             return comment
     return None
 
@@ -108,13 +108,19 @@ def main():
     old_body = preview["body"]
 
     # 3. Build revised JSON with real ID
+    #    Handle both new (DFT-____) and old (T____) placeholder formats
     revised_body = old_body.replace("DFT-____", technique_id)
+    revised_body = revised_body.replace("T____", technique_id)
     revised_body = revised_body.replace(
         "Thanks for proposing a new technique! Here's what it would look like as JSON:",
         "Your technique has been assigned an ID. Here is an updated copy of the JSON data with the ID completed:",
     )
     revised_body = revised_body.replace(
         "The technique ID (DFT-____) will be assigned during review.",
+        f"Technique ID **{technique_id}** has been assigned.",
+    )
+    revised_body = revised_body.replace(
+        "The technique ID (T____) will be assigned during review.",
         f"Technique ID **{technique_id}** has been assigned.",
     )
 

--- a/admin/id_assignment/assign_weakness_id.py
+++ b/admin/id_assignment/assign_weakness_id.py
@@ -47,10 +47,13 @@ def get_issue_comments(issue_number):
 
 
 def find_preview_comment(comments):
-    """Return the preview comment dict that contains the DFW-____ placeholder."""
+    """Return the preview comment dict that contains a weakness ID placeholder.
+
+    Matches both new (DFW-____) and old (W____) placeholder formats.
+    """
     for comment in comments:
         body = comment.get("body", "")
-        if '"id": "DFW-____"' in body:
+        if '"id": "DFW-____"' in body or '"id": "W____"' in body:
             return comment
     return None
 
@@ -94,13 +97,19 @@ def main():
     old_body = preview["body"]
 
     # 3. Build revised JSON with real ID
+    #    Handle both new (DFW-____) and old (W____) placeholder formats
     revised_body = old_body.replace("DFW-____", weakness_id)
+    revised_body = revised_body.replace("W____", weakness_id)
     revised_body = revised_body.replace(
         "Thanks for proposing a new weakness! Here's what it would look like as JSON:",
         "Your weakness has been assigned an ID. Here is an updated copy of the JSON data with the ID completed:",
     )
     revised_body = revised_body.replace(
         "The weakness ID (DFW-____) will be assigned during review.",
+        f"Weakness ID **{weakness_id}** has been assigned.",
+    )
+    revised_body = revised_body.replace(
+        "The weakness ID (W____) will be assigned during review.",
         f"Weakness ID **{weakness_id}** has been assigned.",
     )
 

--- a/admin/id_assignment/find_next_free_ids.py
+++ b/admin/id_assignment/find_next_free_ids.py
@@ -109,8 +109,8 @@ class IDScanner:
                     
                     text_to_search = f"{title} {body} {comment_text}"
                     
-                    # Find technique IDs (T1000-T9999, excluding obvious test cases like T9999)
-                    t_matches = re.findall(r'\bDFT-(1\d{3})\b', text_to_search)
+                    # Find technique IDs — matches both new (DFT-1177) and old (T1177) formats
+                    t_matches = re.findall(r'\b(?:DFT-|T)(1\d{3})\b', text_to_search)
                     for match in t_matches:
                         tid = int(match)
                         # Skip obvious test/placeholder IDs
@@ -123,8 +123,8 @@ class IDScanner:
                             if (number, title, item_type) not in self.reserved_technique_ids[tid]:
                                 self.reserved_technique_ids[tid].append((number, title, item_type))
                     
-                    # Find mitigation IDs (M1000-M9999, excluding single digits)
-                    m_matches = re.findall(r'\bDFM-(1\d{3})\b', text_to_search)
+                    # Find mitigation IDs — matches both new (DFM-1242) and old (M1242) formats
+                    m_matches = re.findall(r'\b(?:DFM-|M)(1\d{3})\b', text_to_search)
                     for match in m_matches:
                         mid = int(match)
                         if mid not in self.mitigation_ids:
@@ -134,8 +134,8 @@ class IDScanner:
                             if (number, title, item_type) not in self.reserved_mitigation_ids[mid]:
                                 self.reserved_mitigation_ids[mid].append((number, title, item_type))
                     
-                    # Find weakness IDs (W1000-W9999, excluding single digits)
-                    w_matches = re.findall(r'\bDFW-(1\d{3})\b', text_to_search)
+                    # Find weakness IDs — matches both new (DFW-1279) and old (W1279) formats
+                    w_matches = re.findall(r'\b(?:DFW-|W)(1\d{3})\b', text_to_search)
                     for match in w_matches:
                         wid = int(match)
                         if wid not in self.weakness_ids:


### PR DESCRIPTION
## Summary
- The ID scanner only matched new-format IDs (`DFT-`/`DFW-`/`DFM-`) when scanning GitHub issues/PRs for reserved IDs, missing old-format IDs (`T`/`W`/`M`) from issues created before the migration (PR #320)
- This caused DFT-1177 to be allocated twice: once for issue #323 (posted as `T1177` pre-migration) and again for issue #328 (as `DFT-1177`)
- Assignment scripts now also handle old-format placeholders (`T____`, `W____`, `M____`) in preview comments

## Files changed
- `admin/id_assignment/find_next_free_ids.py` — scanner regex matches both old and new formats
- `admin/id_assignment/assign_technique_id.py` — handles `T____` placeholders
- `admin/id_assignment/assign_weakness_id.py` — handles `W____` placeholders
- `admin/id_assignment/assign_mitigation_id.py` — handles `M____` placeholders

## Test plan
- [ ] Run `python admin/id_assignment/find_next_free_ids.py` and verify it picks up old-format IDs from issues (e.g. `T1177` in issue #323)
- [ ] Verify validation still passes: `python admin/validate_kb.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)