### PR TITLE
Add subtechnique support to the new-technique automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/1a_propose-new-technique-form.yml
+++ b/.github/ISSUE_TEMPLATE/1a_propose-new-technique-form.yml
@@ -79,6 +79,12 @@ body:
     attributes:
       label: Propose new objective
       description: If your technique doesn't fit an existing objective, propose one here.
+  - type: input
+    id: parent-technique
+    attributes:
+      label: Parent technique ID
+      description: Optional. If this should be a subtechnique of an existing technique, give the parent technique ID (e.g. DFT-1079). It will then be linked from the parent's subtechniques list rather than listed directly under the objective.
+      placeholder: "e.g. DFT-1079"
   - type: markdown
     attributes:
       value: |

--- a/admin/autoimplement_new_item.py
+++ b/admin/autoimplement_new_item.py
@@ -5,8 +5,9 @@ file and opening a PR.
 
 Finds the assigned-ID comment (the revised preview comment posted by the
 assign_{type}_id.py script), extracts the JSON block, writes it to the
-appropriate data/ directory, updates solve-it.json for techniques, and
-opens a PR attributed to the original issue submitter.
+appropriate data/ directory, updates solve-it.json for techniques (or the
+parent technique's subtechniques list when _parent_techniques is present),
+and opens a PR attributed to the original issue submitter.
 
 Handles both DFCite-format references (dicts with DFCite_id) and old-format
 raw string references (matched against the corpus or flagged as PENDING).
@@ -476,6 +477,44 @@ def update_technique_weaknesses(project_root, technique_id, weakness_id):
     return filepath, None
 
 
+def update_technique_subtechniques(project_root, parent_id, subtechnique_id):
+    """Add a technique ID to a parent technique's subtechniques list.
+
+    Returns (filepath_or_None, warning_or_None).
+    """
+    if not VALID_ID_RE.match(parent_id):
+        return None, f"Invalid parent technique ID format: '{parent_id}'"
+
+    filepath = os.path.join(project_root, "data", "techniques", f"{parent_id}.json")
+
+    # Path traversal protection
+    real_dir = os.path.realpath(os.path.join(project_root, "data", "techniques"))
+    real_path = os.path.realpath(filepath)
+    if not real_path.startswith(real_dir + os.sep):
+        return None, f"Path traversal detected for {parent_id}"
+
+    if not os.path.exists(filepath):
+        return None, f"Parent technique file `{parent_id}.json` not found — cannot auto-add subtechnique"
+
+    with open(filepath) as f:
+        data = json.load(f)
+
+    if subtechnique_id in data.get("subtechniques", []):
+        print(f"  {subtechnique_id} already in {parent_id}'s subtechniques list", file=sys.stderr)
+        return None, None
+
+    if "subtechniques" not in data:
+        data["subtechniques"] = []
+    data["subtechniques"].append(subtechnique_id)
+
+    with open(filepath, 'w') as f:
+        json.dump(data, f, indent=4)
+        f.write('\n')
+
+    print(f"  Added {subtechnique_id} to {parent_id}'s subtechniques list", file=sys.stderr)
+    return filepath, None
+
+
 def update_weakness_mitigations(project_root, weakness_id, mitigation_id):
     """Add a mitigation ID to a weakness's mitigations list.
 
@@ -750,14 +789,32 @@ def main():
 
         written_files = [filepath]
 
-        # 10. Update solve-it.json for techniques
+        # 10. Update solve-it.json for techniques.
+        # Subtechniques (a parent technique was given) are reached via the
+        # parent's subtechniques list, not the objective list, so skip.
         if item_type == "technique" and objective_name:
-            if update_solve_it_json(write_root, objective_name, item_id):
+            if parent_techniques:
+                print(f"  Parent technique specified — not adding {item_id} to "
+                      f"objective '{objective_name}' in solve-it.json", file=sys.stderr)
+            elif update_solve_it_json(write_root, objective_name, item_id):
                 solve_it_path = os.path.join(write_root, "data", "solve-it.json")
                 written_files.append(solve_it_path)
 
         # 10b. Update parent items
         parent_update_warnings = []
+
+        if item_type == "technique":
+            for tid in parent_techniques:
+                normalized = normalize_id(tid)
+                if not normalized:
+                    parent_update_warnings.append(
+                        f"Could not update parent technique `{tid}` — invalid ID format")
+                    continue
+                fpath, warning = update_technique_subtechniques(write_root, normalized, item_id)
+                if fpath:
+                    written_files.append(fpath)
+                if warning:
+                    parent_update_warnings.append(warning)
 
         if item_type == "weakness":
             for tid in parent_techniques:
@@ -855,7 +912,10 @@ def main():
         pr_lines.append(f"| Type | {type_label} |")
         pr_lines.append(f"| ID | `{item_id}` |")
         pr_lines.append(f"| Name | {item_name} |")
-        if objective_name:
+        if item_type == "technique" and parent_techniques:
+            parents = ", ".join(f"`{normalize_id(t) or t}`" for t in parent_techniques)
+            pr_lines.append(f"| Parent technique | {parents} |")
+        elif objective_name:
             pr_lines.append(f"| Objective | {objective_name} |")
         pr_lines.append("")
 

--- a/admin/issue_parsers/parse_technique_issue.py
+++ b/admin/issue_parsers/parse_technique_issue.py
@@ -101,6 +101,14 @@ def build_technique_json(fields, project_root=None):
         "CASE_output_classes": lines_to_list(fields.get("Ontology output classes", "")),
         "references": processed_refs,
     }
+
+    # Optional parent technique — makes this a subtechnique. Carried in the
+    # preview JSON as _parent_techniques (stripped before the data file is
+    # written, mirroring the weakness parser's parent mechanism).
+    parent_techniques = lines_to_list(fields.get("Parent technique ID", ""))
+    if parent_techniques:
+        technique["_parent_techniques"] = parent_techniques
+
     return technique, match_report, new_citations, ref_warnings
 
 
@@ -160,6 +168,27 @@ def build_comment(technique, fields, match_report=None, new_citations=None, ref_
         for w in new_weaknesses:
             url = build_weakness_link(w)
             lines.append(f"- [`{w}`]({url})")
+
+    # Parent technique (subtechnique placement)
+    parent_techniques = technique.get("_parent_techniques", [])
+    if parent_techniques:
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+        lines.append("### Parent technique")
+        lines.append("")
+        lines.append("This technique is proposed as a subtechnique of:")
+        lines.append("")
+        for tid in parent_techniques:
+            lines.append(f"- Technique **{tid}**")
+        lines.append("")
+        lines.append("On implementation it will be added to the parent's subtechniques list "
+                      "instead of directly under the objective.")
+        for tid in parent_techniques:
+            if not re.match(r'^(DFT-|T)\d{4,6}$', tid):
+                lines.append("")
+                lines.append(f":warning: `{tid}` does not look like a valid technique ID "
+                             "(expected e.g. DFT-1079) — this will need correcting before implementation.")
 
     # Next steps
     objective = fields.get("Objective", "").strip()

--- a/tests/test_autoimplement_new_item.py
+++ b/tests/test_autoimplement_new_item.py
@@ -572,6 +572,72 @@ class TestUpdateTechniqueWeaknesses(unittest.TestCase):
         self.assertIn("Invalid", warning)
 
 
+class TestUpdateTechniqueSubtechniques(unittest.TestCase):
+    """Test adding subtechnique IDs to parent technique files."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.tmpdir, "data", "techniques"))
+        self.parent = {
+            "id": "DFT-1079",
+            "name": "Examine audio content",
+            "subtechniques": [],
+            "references": [],
+        }
+        self.filepath = os.path.join(self.tmpdir, "data", "techniques", "DFT-1079.json")
+        with open(self.filepath, "w") as f:
+            json.dump(self.parent, f, indent=4)
+            f.write('\n')
+
+    def test_adds_subtechnique(self):
+        fpath, warning = mod.update_technique_subtechniques(self.tmpdir, "DFT-1079", "DFT-1200")
+        self.assertIsNotNone(fpath)
+        self.assertIsNone(warning)
+        with open(self.filepath) as f:
+            data = json.load(f)
+        self.assertIn("DFT-1200", data["subtechniques"])
+
+    def test_duplicate_skipped(self):
+        mod.update_technique_subtechniques(self.tmpdir, "DFT-1079", "DFT-1200")
+        fpath, warning = mod.update_technique_subtechniques(self.tmpdir, "DFT-1079", "DFT-1200")
+        self.assertIsNone(fpath)
+        self.assertIsNone(warning)
+        with open(self.filepath) as f:
+            data = json.load(f)
+        self.assertEqual(data["subtechniques"].count("DFT-1200"), 1)
+
+    def test_creates_subtechniques_key_if_missing(self):
+        del self.parent["subtechniques"]
+        with open(self.filepath, "w") as f:
+            json.dump(self.parent, f, indent=4)
+            f.write('\n')
+        fpath, warning = mod.update_technique_subtechniques(self.tmpdir, "DFT-1079", "DFT-1200")
+        self.assertIsNotNone(fpath)
+        self.assertIsNone(warning)
+        with open(self.filepath) as f:
+            data = json.load(f)
+        self.assertEqual(data["subtechniques"], ["DFT-1200"])
+
+    def test_missing_file_returns_warning(self):
+        fpath, warning = mod.update_technique_subtechniques(self.tmpdir, "DFT-9999", "DFT-1200")
+        self.assertIsNone(fpath)
+        self.assertIsNotNone(warning)
+        self.assertIn("not found", warning)
+
+    def test_invalid_id_returns_warning(self):
+        fpath, warning = mod.update_technique_subtechniques(self.tmpdir, "INVALID", "DFT-1200")
+        self.assertIsNone(fpath)
+        self.assertIsNotNone(warning)
+        self.assertIn("Invalid", warning)
+
+    def test_other_fields_preserved(self):
+        mod.update_technique_subtechniques(self.tmpdir, "DFT-1079", "DFT-1200")
+        with open(self.filepath) as f:
+            data = json.load(f)
+        self.assertEqual(data["name"], "Examine audio content")
+        self.assertEqual(data["references"], [])
+
+
 class TestUpdateWeaknessMitigations(unittest.TestCase):
     """Test adding mitigation IDs to parent weakness files."""
 
@@ -643,6 +709,23 @@ class TestMetadataStripping(unittest.TestCase):
             data = json.load(f)
         self.assertNotIn("_parent_techniques", data)
         self.assertNotIn("_parent_weaknesses", data)
+
+    def test_parent_techniques_not_in_written_technique_file(self):
+        block = {
+            "id": "DFT-9999",
+            "name": "Test subtechnique",
+            "subtechniques": [],
+            "weaknesses": [],
+            "references": [],
+            "_parent_techniques": ["DFT-1079"],
+        }
+        block.pop("_parent_techniques", [])
+        block.pop("_parent_weaknesses", [])
+        path = mod.write_data_file(self.tmpdir, "technique", block)
+        with open(path) as f:
+            data = json.load(f)
+        self.assertNotIn("_parent_techniques", data)
+        self.assertEqual(data["subtechniques"], [])
 
     def test_parent_weaknesses_not_in_written_file(self):
         block = {

--- a/tests/test_parse_technique_issue.py
+++ b/tests/test_parse_technique_issue.py
@@ -1,0 +1,162 @@
+"""Tests for admin/issue_parsers/parse_technique_issue.py — including the
+parent technique (subtechnique) field."""
+
+import json
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'admin', 'issue_parsers'))
+from parse_technique_issue import (
+    build_comment,
+    build_technique_json,
+    parse_issue_body,
+)
+
+
+def _make_fields(parent=""):
+    return {
+        "Technique name": "Test technique",
+        "Description": "A test description.",
+        "Synonyms": "",
+        "Details": "",
+        "Examples": "",
+        "Objective": "Review content for relevance",
+        "Propose new objective": "_No response_",
+        "Parent technique ID": parent,
+        "Existing weakness IDs": "",
+        "Propose new weaknesses": "",
+        "Ontology input classes": "",
+        "Ontology output classes": "",
+        "References": "",
+    }
+
+
+class TestParseIssueBody(unittest.TestCase):
+
+    def test_parses_parent_technique_field(self):
+        body = (
+            "### Technique name\n\nTest technique\n\n"
+            "### Parent technique ID\n\nDFT-1079\n\n"
+            "### Any other notes\n\n_No response_\n"
+        )
+        fields = parse_issue_body(body)
+        self.assertEqual(fields["Parent technique ID"], "DFT-1079")
+
+    def test_missing_parent_technique_field(self):
+        body = "### Technique name\n\nTest technique\n"
+        fields = parse_issue_body(body)
+        self.assertNotIn("Parent technique ID", fields)
+
+
+class TestBuildTechniqueJsonParent(unittest.TestCase):
+
+    def test_parent_included_when_given(self):
+        technique, _, _, _ = build_technique_json(_make_fields("DFT-1079"))
+        self.assertEqual(technique["_parent_techniques"], ["DFT-1079"])
+
+    def test_parent_absent_when_blank(self):
+        technique, _, _, _ = build_technique_json(_make_fields(""))
+        self.assertNotIn("_parent_techniques", technique)
+
+    def test_parent_absent_when_no_response(self):
+        technique, _, _, _ = build_technique_json(_make_fields("_No response_"))
+        self.assertNotIn("_parent_techniques", technique)
+
+    def test_parent_absent_when_field_missing(self):
+        fields = _make_fields()
+        del fields["Parent technique ID"]
+        technique, _, _, _ = build_technique_json(fields)
+        self.assertNotIn("_parent_techniques", technique)
+
+    def test_subtechniques_still_empty_list(self):
+        technique, _, _, _ = build_technique_json(_make_fields("DFT-1079"))
+        self.assertEqual(technique["subtechniques"], [])
+
+    def test_whitespace_stripped(self):
+        technique, _, _, _ = build_technique_json(_make_fields("  DFT-1079  "))
+        self.assertEqual(technique["_parent_techniques"], ["DFT-1079"])
+
+
+class TestBuildCommentParent(unittest.TestCase):
+
+    def _json_block(self, comment):
+        match = re.search(r'```json\s*\n(.*?)\n```', comment, re.DOTALL)
+        self.assertIsNotNone(match)
+        return json.loads(match.group(1))
+
+    def test_comment_mentions_parent(self):
+        fields = _make_fields("DFT-1079")
+        technique, _, _, _ = build_technique_json(fields)
+        comment = build_comment(technique, fields)
+        self.assertIn("### Parent technique", comment)
+        self.assertIn("DFT-1079", comment)
+        self.assertIn("subtechnique", comment)
+
+    def test_comment_json_carries_parent(self):
+        """The preview JSON must include _parent_techniques so that the
+        assign-ID and autoimplement steps can pick it up from the comment."""
+        fields = _make_fields("DFT-1079")
+        technique, _, _, _ = build_technique_json(fields)
+        comment = build_comment(technique, fields)
+        block = self._json_block(comment)
+        self.assertEqual(block["_parent_techniques"], ["DFT-1079"])
+
+    def test_comment_no_parent_section_without_parent(self):
+        fields = _make_fields("")
+        technique, _, _, _ = build_technique_json(fields)
+        comment = build_comment(technique, fields)
+        self.assertNotIn("### Parent technique", comment)
+        self.assertNotIn("_parent_techniques", comment)
+
+    def test_comment_warns_on_invalid_parent_id(self):
+        fields = _make_fields("Examine audio content")
+        technique, _, _, _ = build_technique_json(fields)
+        comment = build_comment(technique, fields)
+        self.assertIn(":warning:", comment)
+        self.assertIn("does not look like a valid technique ID", comment)
+
+    def test_comment_accepts_old_format_id(self):
+        fields = _make_fields("T1079")
+        technique, _, _, _ = build_technique_json(fields)
+        comment = build_comment(technique, fields)
+        self.assertNotIn("does not look like a valid technique ID", comment)
+
+
+class TestEndToEndBody(unittest.TestCase):
+    """Simulate a full GitHub form body through parse + build + comment."""
+
+    BODY = (
+        "### Technique name\n\n"
+        "Classify if audio is potentially synthetically generated\n\n"
+        "### Description\n\n"
+        "```text\nClassification of audio with respect to its origin.\n```\n\n"
+        "### Synonyms\n\n"
+        "```text\nAudio deepfake detection\n```\n\n"
+        "### Objective\n\n"
+        "Review content for relevance\n\n"
+        "### Propose new objective\n\n"
+        "_No response_\n\n"
+        "### Parent technique ID\n\n"
+        "DFT-1079\n\n"
+        "### Existing weakness IDs\n\n"
+        "```text\n\n```\n\n"
+        "### Any other notes\n\n"
+        "_No response_\n"
+    )
+
+    def test_full_flow(self):
+        fields = parse_issue_body(self.BODY)
+        technique, _, _, _ = build_technique_json(fields)
+        self.assertEqual(technique["_parent_techniques"], ["DFT-1079"])
+        comment = build_comment(technique, fields)
+        match = re.search(r'```json\s*\n(.*?)\n```', comment, re.DOTALL)
+        block = json.loads(match.group(1))
+        self.assertEqual(block["name"],
+                         "Classify if audio is potentially synthetically generated")
+        self.assertEqual(block["_parent_techniques"], ["DFT-1079"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds an optional "Parent technique ID" field to the 'create new technique' form. The parser carries it through the preview JSON as _parent_techniques (mirroring the weakness parser's parent mechanism), and autoimplement adds the new technique to the parent's subtechniques list instead of listing it under the objective in solve-it.json.
