### PR TITLE
WIP: emit techniques as classes for the UCO 1.5.0 metaclass model

### DIFF
--- a/admin/validate_kb.py
+++ b/admin/validate_kb.py
@@ -626,9 +626,9 @@ def phase4_case_urls(techniques: Dict, result: ValidationResult, verbose: bool,
         )
         # Load additional UCO modules referenced by the KB
         extra_modules = [
-            "https://raw.githubusercontent.com/ucoProject/UCO/1.4.0/ontology/uco/configuration/configuration.ttl",
-            "https://raw.githubusercontent.com/ucoProject/UCO/1.4.0/ontology/uco/identity/identity.ttl",
-            "https://raw.githubusercontent.com/ucoProject/UCO/1.4.0/ontology/uco/location/location.ttl",
+            "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/configuration/configuration.ttl",
+            "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/identity/identity.ttl",
+            "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/location/location.ttl",
         ]
         lookup._load_remote_modules(extra_modules)
 

--- a/reporting_scripts/generate_rdf_from_kb.py
+++ b/reporting_scripts/generate_rdf_from_kb.py
@@ -27,7 +27,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from solve_it_library import KnowledgeBase
-from rdflib import Graph, Namespace, Literal, URIRef, RDF, RDFS, XSD
+from rdflib import Graph, Namespace, Literal, URIRef, RDF, RDFS, OWL, XSD
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -44,6 +44,7 @@ SOLVEIT_DATA = Namespace("https://ontology.solveit-df.org/solveit/data/")
 # External ontologies
 UCO_CORE = Namespace("https://ontology.unifiedcyberontology.org/uco/core/")
 UCO_OBSERVABLE = Namespace("https://ontology.unifiedcyberontology.org/uco/observable/")
+UCO_ACTION = Namespace("https://ontology.unifiedcyberontology.org/uco/action/")
 CASE_INVESTIGATION = Namespace("https://ontology.caseontology.org/case/investigation/")
 
 
@@ -67,9 +68,11 @@ def create_rdf_graph(kb, include_objectives=True):
     g.bind("solveit-analysis", SOLVEIT_ANALYSIS)
     g.bind("uco-core", UCO_CORE)
     g.bind("uco-observable", UCO_OBSERVABLE)
+    g.bind("uco-action", UCO_ACTION)
     g.bind("case-investigation", CASE_INVESTIGATION)
     g.bind("rdf", RDF)
     g.bind("rdfs", RDFS)
+    g.bind("owl", OWL)
     g.bind("xsd", XSD)
 
     logger.info("Building RDF graph from knowledge base...")
@@ -100,9 +103,38 @@ def create_rdf_graph(kb, include_objectives=True):
     return g
 
 
+def build_parent_map(kb, techniques):
+    """Map each sub-technique ID to the technique ID(s) that declare it.
+
+    The KB records the relationship in one direction only: a parent lists its
+    subtechniques. The metaclass model needs the reverse, because a
+    sub-technique is expressed as rdfs:subClassOf its parent.
+    """
+    parents = {}
+    for tech_id in techniques:
+        tech = kb.get_technique(tech_id)
+        for sub_id in tech.get('subtechniques', []):
+            parents.setdefault(sub_id, []).append(tech_id)
+    return parents
+
+
 def add_techniques_to_graph(g, kb):
-    """Add all techniques to the RDF graph."""
+    """Add all techniques to the RDF graph.
+
+    Each technique is emitted under the uco-action:Technique metaclass pattern
+    introduced in UCO 1.5.0: it is both an instance of solveit-core:Technique
+    and an owl:Class in its own right, so that a performed investigative action
+    can state which technique it implements by rdf:type.
+
+    UCO requires a Technique instance to be a subclass of uco-action:Action.
+    SOLVE-IT satisfies this by placing root techniques under
+    solveit-core:SolveitInvestigativeAction, which descends from
+    case-investigation:InvestigativeAction and so from uco-action:Action.
+    Sub-techniques inherit it through their parent.
+    """
     techniques = kb.list_techniques()
+    parent_map = build_parent_map(kb, techniques)
+    referenced_classes = set()
 
     for tech_id in techniques:
         tech = kb.get_technique(tech_id)
@@ -110,8 +142,19 @@ def add_techniques_to_graph(g, kb):
         # Create URI for this technique (instance in data namespace)
         tech_uri = SOLVEIT_DATA[f"technique{tech_id}"]
 
-        # Add type
+        # Add type: an instance of the Technique metaclass, and a class itself
         g.add((tech_uri, RDF.type, SOLVEIT_CORE.Technique))
+        g.add((tech_uri, RDF.type, OWL.Class))
+
+        # Place the technique class in the action hierarchy. A sub-technique
+        # sits under its parent; a root technique sits under
+        # SolveitInvestigativeAction directly.
+        parent_ids = parent_map.get(tech_id, [])
+        if parent_ids:
+            for parent_id in parent_ids:
+                g.add((tech_uri, RDFS.subClassOf, SOLVEIT_DATA[f"technique{parent_id}"]))
+        else:
+            g.add((tech_uri, RDFS.subClassOf, SOLVEIT_CORE.SolveitInvestigativeAction))
 
         # Add label
         g.add((tech_uri, RDFS.label, Literal(f"{tech_id}: {tech['name']}", lang="en")))
@@ -153,14 +196,23 @@ def add_techniques_to_graph(g, kb):
             weakness_uri = SOLVEIT_DATA[f"weakness{weakness_id}"]
             g.add((tech_uri, SOLVEIT_CORE.hasPotentialWeakness, weakness_uri))
 
-        # Add CASE input classes (as xsd:anyURI typed literals)
+        # Add CASE input classes as IRI references, not string literals, so a
+        # reasoner can follow them and a validator can check them.
         for case_class_uri in tech.get('CASE_input_classes', []):
-            g.add((tech_uri, SOLVEIT_CORE.hasCASEInputClass, Literal(case_class_uri, datatype=XSD.anyURI)))
+            g.add((tech_uri, SOLVEIT_CORE.hasCASEInputClass, URIRef(case_class_uri)))
+            referenced_classes.add(case_class_uri)
 
-        # Add CASE output classes (as xsd:anyURI typed literals)
+        # Add CASE output classes (already full URIs in the JSON)
         for case_class_uri in tech.get('CASE_output_classes', []):
-            # CASE_output_classes are already full URIs in the JSON
-            g.add((tech_uri, SOLVEIT_CORE.hasCASEOutputClass, Literal(case_class_uri, datatype=XSD.anyURI)))
+            g.add((tech_uri, SOLVEIT_CORE.hasCASEOutputClass, URIRef(case_class_uri)))
+            referenced_classes.add(case_class_uri)
+
+    # Declare every referenced input/output class as an owl:Class. Without a
+    # declaration, an IRI used in class position is a declaration error under
+    # OWL 2 DL. This states only that the IRI names a class, which is what the
+    # KB is asserting anyway; it makes no claim about the class's definition.
+    for class_uri in sorted(referenced_classes):
+        g.add((URIRef(class_uri), RDF.type, OWL.Class))
 
 
 def add_weaknesses_to_graph(g, kb):

--- a/reporting_scripts/generate_rdf_from_kb.py
+++ b/reporting_scripts/generate_rdf_from_kb.py
@@ -19,6 +19,7 @@ Example:
 """
 
 import argparse
+import json
 import sys
 import os
 import logging
@@ -546,6 +547,112 @@ def serialize_grouped(g):
     return '\n'.join(out)
 
 
+def jsonld_node_order(g):
+    """Map each subject IRI to its position in the Turtle section layout.
+
+    JSON-LD in expanded form is a flat array, and an array is ordered, so a
+    reader gets the same objectives -> techniques -> weaknesses -> mitigations ->
+    citations progression as the Turtle instead of one alphabetical run of IRIs.
+    Sorting by @id, as the previous version did, put citations first and split
+    the objectives away from the techniques they list.
+
+    Returns {subject IRI: (section index, position within section)}, built by the
+    same rules serialize_grouped() uses, so the two formats cannot drift.
+    """
+    order = {}
+    claimed = set()
+    for index, (_, _, type_uri, _, sort_pred) in enumerate(TTL_SECTIONS):
+        subjects = sorted(
+            set(g.subjects(RDF.type, type_uri)),
+            key=lambda s: _section_key(s, g, sort_pred),
+        )
+        claimed.update(subjects)
+        for position, subject in enumerate(subjects):
+            order.setdefault(str(subject), (index, position))
+
+    # The declaration-only CASE/UCO class stubs, in the same trailing block the
+    # Turtle gives them.
+    remaining = sorted((s for s in set(g.subjects()) if s not in claimed),
+                       key=lambda s: _natural_key(s, g))
+    for position, subject in enumerate(remaining):
+        order.setdefault(str(subject), (len(TTL_SECTIONS), position))
+    return order
+
+
+def sort_jsonld_values(node):
+    """Sort every multi-valued property of one JSON-LD node, in place.
+
+    rdflib emits each object list in graph iteration order, which carries no
+    meaning and can be reshuffled by an unrelated edit elsewhere in the knowledge
+    base — so a diff between two builds showed changes that were not changes.
+    The Turtle already sorts these lists; this brings the JSON-LD into line.
+    """
+    for value in node.values():
+        if isinstance(value, list) and len(value) > 1:
+            value.sort(key=lambda v: json.dumps(v, sort_keys=True, ensure_ascii=False))
+    return node
+
+
+def _sorted_nested(value):
+    """Rebuild the {"@id": ...} / {"@value": ...} objects with their keys sorted.
+
+    The document keys are ordered deliberately by reorder_jsonld_keys(), so the
+    writer cannot use json.dump(sort_keys=True) to make the file deterministic;
+    the small nested objects are sorted here instead.
+    """
+    if isinstance(value, dict):
+        return {key: _sorted_nested(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_sorted_nested(item) for item in value]
+    return value
+
+
+def reorder_jsonld_keys(node, pred_order):
+    """Return one node with its properties in the order the Turtle uses.
+
+    Identity first (@id, @type, label, placement in the class hierarchy), then
+    the section's preferred predicate order, then anything left over
+    alphabetically — the same rules as _emit_subject(). Sorting the keys instead
+    puts techniqueID and techniqueName after the has* lists, which reads oddly
+    for what is meant to be the readable form of the same data.
+    """
+    preferred = ['@id', '@type', str(RDFS.label), str(RDFS.subClassOf)]
+    preferred += [str(SOLVEIT_CORE[name]) for name in pred_order]
+    rank = {key: index for index, key in enumerate(preferred)}
+    keys = sorted(node, key=lambda k: (rank.get(k, len(rank)), k))
+    return {key: _sorted_nested(node[key]) for key in keys}
+
+
+def order_jsonld(jsonld_data, g):
+    """Order a parsed expanded JSON-LD document for reading and for stable diffs.
+
+    Handles both shapes rdflib can return: a bare array of nodes, or an object
+    with an @graph array.
+    """
+    order = jsonld_node_order(g)
+    # Predicate order per section, with an empty order for the trailing
+    # declaration-only block and for anything the graph did not account for.
+    pred_orders = [section[3] for section in TTL_SECTIONS] + [[], []]
+    # Nodes the graph did not account for sort after the known sections, by @id,
+    # rather than staying in whatever order they arrived in.
+    fallback = (len(TTL_SECTIONS) + 1, 0)
+
+    def ordered_nodes(nodes):
+        for node in nodes:
+            sort_jsonld_values(node)
+        nodes.sort(key=lambda n: order.get(n.get('@id', ''), fallback) + (n.get('@id', ''),))
+        return [
+            reorder_jsonld_keys(node, pred_orders[order.get(node.get('@id', ''), fallback)[0]])
+            for node in nodes
+        ]
+
+    if isinstance(jsonld_data, list):
+        return ordered_nodes(jsonld_data)
+    if isinstance(jsonld_data, dict) and '@graph' in jsonld_data:
+        jsonld_data['@graph'] = ordered_nodes(jsonld_data['@graph'])
+    return jsonld_data
+
+
 def save_graph(g, output_dir, format_type='both'):
     """
     Save the RDF graph to file(s).
@@ -571,17 +678,15 @@ def save_graph(g, output_dir, format_type='both'):
     if format_type in ['jsonld', 'both']:
         jsonld_file = output_path / 'solve-it-kb.jsonld'
         logger.info(f"Writing JSON-LD output to {jsonld_file}")
-        # Serialize to string, then sort for deterministic output
-        import json
+        # Serialize to string, then order it: nodes into the same sections as the
+        # Turtle, and every multi-valued property sorted, so the file reads in
+        # knowledge base order and diffs cleanly between builds.
         jsonld_str = g.serialize(format='json-ld')
-        jsonld_data = json.loads(jsonld_str)
-        # Sort @graph entries by @id for stable diffs
-        if isinstance(jsonld_data, list):
-            jsonld_data.sort(key=lambda x: x.get('@id', ''))
-        elif isinstance(jsonld_data, dict) and '@graph' in jsonld_data:
-            jsonld_data['@graph'].sort(key=lambda x: x.get('@id', ''))
+        jsonld_data = order_jsonld(json.loads(jsonld_str), g)
         with open(jsonld_file, 'w', encoding='utf-8') as f:
-            json.dump(jsonld_data, f, indent=2, sort_keys=True, ensure_ascii=False)
+            # No sort_keys: order_jsonld() has already put the keys in the order
+            # the Turtle uses, and sorting would undo it.
+            json.dump(jsonld_data, f, indent=2, ensure_ascii=False)
             f.write('\n')
         logger.info(f"JSON-LD file written successfully: {jsonld_file}")
 

--- a/reporting_scripts/generate_rdf_from_kb.py
+++ b/reporting_scripts/generate_rdf_from_kb.py
@@ -347,6 +347,205 @@ def add_objectives_to_graph(g, kb):
             g.add((obj_uri, SOLVEIT_CORE.includesTechnique, tech_uri))
 
 
+# Section layout for the Turtle output. rdflib's own serializer emits subjects
+# in an order that interleaves techniques, weaknesses, mitigations and citations,
+# which makes the file hard to read and hard to diff. Each entry is
+# (heading, blurb, rdf:type to select on, predicate order within a subject,
+#  predicate to sort subjects by — None to sort by identifier).
+TTL_SECTIONS = [
+    (
+        'Objectives',
+        'Investigation objectives, each listing the techniques that can achieve it.\n'
+        '#    Ordered by solveit-core:sortOrder, which is the order objectives are\n'
+        '#    worked through in an investigation, not by DFO identifier.',
+        SOLVEIT_CORE.Objective,
+        ['objectiveID', 'objectiveName', 'objectiveDescription', 'sortOrder',
+         'includesTechnique'],
+        SOLVEIT_CORE.sortOrder,
+    ),
+    (
+        'Techniques',
+        'Each technique is an instance of the solveit-core:Technique metaclass AND\n'
+        '#    an owl:Class in its own right, following uco-action:Technique (UCO 1.5.0).\n'
+        '#    A performed investigative action is typed with the technique class it\n'
+        '#    implements. Root techniques are rdfs:subClassOf\n'
+        '#    solveit-core:SolveitInvestigativeAction; sub-techniques are\n'
+        '#    rdfs:subClassOf their parent technique and inherit the anchor through it.',
+        SOLVEIT_CORE.Technique,
+        ['techniqueID', 'techniqueName', 'techniqueDescription', 'techniqueDetails',
+         'hasSynonym', 'hasExample', 'hasCASEInputClass', 'hasCASEOutputClass',
+         'hasPotentialWeakness', 'hasSubtechnique', 'hasReference'],
+        None,
+    ),
+    (
+        'Weaknesses',
+        'Potential problems arising from a technique, classified against the\n'
+        '#    ASTM E3016-18 error categories.',
+        SOLVEIT_CORE.Weakness,
+        ['weaknessID', 'weaknessName', 'weaknessDescription', 'hasWeaknessClass',
+         'hasPotentialMitigation', 'hasReference'],
+        None,
+    ),
+    (
+        'Mitigations',
+        'Actions that prevent a weakness or reduce its impact.',
+        SOLVEIT_CORE.Mitigation,
+        ['mitigationID', 'mitigationName', 'mitigationDescription',
+         'linksToTechnique', 'hasReference'],
+        None,
+    ),
+    (
+        'Citations',
+        'Reference sources, cited by DFCite id from techniques, weaknesses\n'
+        '#    and mitigations.',
+        SOLVEIT_CORE.Citation,
+        ['citationID', 'citationPlaintext', 'citationBibtex'],
+        None,
+    ),
+]
+
+
+def _natural_key(term, g):
+    """Sort key that orders DFT-1002 before DFT-1042 before DFT-1123.
+
+    Plain string sorting puts DFT-1123 before DFT-142, which is not what a
+    reader expects. Split the local name into text and numeric runs instead.
+    """
+    import re
+    local = str(term).rsplit('/', 1)[-1]
+    return tuple(
+        int(part) if part.isdigit() else part
+        for part in re.split(r'(\d+)', local)
+    )
+
+
+def _section_key(subject, g, sort_pred):
+    """Order subjects within a section.
+
+    By identifier unless the section names a predicate to sort on, in which case
+    that value leads and the identifier breaks ties. Objectives use
+    solveit-core:sortOrder so the section reads in investigation order rather
+    than by DFO number.
+    """
+    ident = _natural_key(subject, g)
+    if sort_pred is None:
+        return (0, ident)
+    value = next(g.objects(subject, sort_pred), None)
+    if value is None:
+        # Anything lacking the sort value goes last, still ordered by identifier.
+        return (1, ident)
+    return (0, (value.toPython(),), ident)
+
+
+def _emit_subject(g, subject, pred_order, nm):
+    """Render one subject as a Turtle block with predicates in a chosen order."""
+    lines = []
+    by_pred = {}
+    for p, o in g.predicate_objects(subject):
+        by_pred.setdefault(p, []).append(o)
+
+    def clause(pred_n3, objs):
+        rendered = sorted(o.n3(nm) for o in objs)
+        if len(rendered) == 1:
+            return f"    {pred_n3} {rendered[0]}"
+        joined = (',\n' + ' ' * (4 + len(pred_n3) + 1)).join(rendered)
+        return f"    {pred_n3} {joined}"
+
+    emitted = set()
+
+    # Types first, then label, then placement in the class hierarchy.
+    for pred, pred_n3 in ((RDF.type, 'a'), (RDFS.label, 'rdfs:label'),
+                          (RDFS.subClassOf, 'rdfs:subClassOf')):
+        if pred in by_pred:
+            lines.append(clause(pred_n3, by_pred[pred]))
+            emitted.add(pred)
+
+    # Then the section's preferred order, then anything left over.
+    ordered = [SOLVEIT_CORE[name] for name in pred_order]
+    leftovers = sorted((p for p in by_pred if p not in emitted and p not in ordered),
+                       key=str)
+    for pred in ordered + leftovers:
+        if pred in by_pred and pred not in emitted:
+            lines.append(clause(pred.n3(nm), by_pred[pred]))
+            emitted.add(pred)
+
+    return f"{subject.n3(nm)}\n" + " ;\n".join(lines) + " .\n"
+
+
+def serialize_grouped(g):
+    """Serialize the graph as Turtle grouped into commented sections.
+
+    Produces the same triples as g.serialize(format='turtle') but ordered so the
+    file can be read top to bottom and diffed sensibly between builds.
+    """
+    nm = g.namespace_manager
+    out = []
+
+    # rdflib pre-binds a long list of well-known vocabularies (brick, csvw,
+    # dcat and so on). Emit only the prefixes the graph actually uses.
+    used = set()
+    for triple in g:
+        for term in triple:
+            if isinstance(term, URIRef):
+                used.add(str(term))
+            elif isinstance(term, Literal) and term.datatype:
+                used.add(str(term.datatype))
+    out.append('\n'.join(
+        f"@prefix {prefix if prefix else ''}: <{uri}> ."
+        for prefix, uri in sorted(nm.namespaces(), key=lambda x: x[0])
+        if any(t.startswith(str(uri)) for t in used)
+    ))
+    out.append('')
+
+    counts = {t: len(set(g.subjects(RDF.type, t))) for _, _, t, _, _ in TTL_SECTIONS}
+    rule = '#' * 65
+    out.append(rule)
+    out.append('#    SOLVE-IT Knowledge Base')
+    out.append('#')
+    out.append('#    Generated from the SOLVE-IT knowledge base JSON by')
+    out.append('#    reporting_scripts/generate_rdf_from_kb.py. Do not edit by hand.')
+    out.append('#')
+    for heading, _, type_uri, _, _ in TTL_SECTIONS:
+        out.append(f"#      {heading + ':':<16}{counts[type_uri]}")
+    out.append(rule)
+    out.append('')
+
+    claimed = set()
+    for heading, blurb, type_uri, pred_order, sort_pred in TTL_SECTIONS:
+        subjects = sorted(
+            set(g.subjects(RDF.type, type_uri)),
+            key=lambda s: _section_key(s, g, sort_pred),
+        )
+        claimed.update(subjects)
+        out.append(rule)
+        out.append(f"#    {heading} ({len(subjects)})")
+        out.append('#')
+        out.append(f"#    {blurb}")
+        out.append(rule)
+        out.append('')
+        for s in subjects:
+            out.append(_emit_subject(g, s, pred_order, nm))
+
+    # Declaration-only stubs for the CASE/UCO classes referenced as technique
+    # inputs and outputs. Without these an IRI in class position is a
+    # declaration error under OWL 2 DL.
+    remaining = sorted((s for s in set(g.subjects()) if s not in claimed),
+                       key=lambda s: _natural_key(s, g))
+    if remaining:
+        out.append(rule)
+        out.append(f"#    Referenced CASE/UCO classes ({len(remaining)})")
+        out.append('#')
+        out.append('#    Declaration only. These name classes defined in CASE/UCO or in')
+        out.append('#    the SOLVE-IT observable modules, referenced above as technique')
+        out.append('#    input and output classes. No definition is asserted here.')
+        out.append(rule)
+        out.append('')
+        for s in remaining:
+            out.append(_emit_subject(g, s, [], nm))
+
+    return '\n'.join(out)
+
+
 def save_graph(g, output_dir, format_type='both'):
     """
     Save the RDF graph to file(s).
@@ -362,8 +561,9 @@ def save_graph(g, output_dir, format_type='both'):
     if format_type in ['ttl', 'both']:
         ttl_file = output_path / 'solve-it-kb.ttl'
         logger.info(f"Writing Turtle output to {ttl_file}")
-        # rdflib Turtle serializer sorts by subject; write with consistent encoding
-        ttl_output = g.serialize(format='turtle')
+        # Grouped into commented sections rather than rdflib's own subject order,
+        # which interleaves techniques, weaknesses, mitigations and citations.
+        ttl_output = serialize_grouped(g)
         with open(ttl_file, 'w', encoding='utf-8') as f:
             f.write(ttl_output)
         logger.info(f"Turtle file written successfully: {ttl_file}")

--- a/solve_it_library/ontology_utils.py
+++ b/solve_it_library/ontology_utils.py
@@ -17,6 +17,7 @@ Usage:
 
 import json
 import logging
+import re
 import urllib.request
 from pathlib import Path
 
@@ -75,11 +76,11 @@ def _discover_solveit_ttl_files(base_api_url=SOLVEIT_ONTOLOGY_GITHUB_API):
         logger.warning(f"Could not discover SOLVE-IT TTL files from GitHub: {exc}")
         return None
 
-# UCO/CASE ontology module URLs for 1.4.0
+# UCO/CASE ontology module URLs for 1.5.0
 UCO_CASE_MODULES = [
-    "https://raw.githubusercontent.com/ucoProject/UCO/1.4.0/ontology/uco/core/core.ttl",
-    "https://raw.githubusercontent.com/ucoProject/UCO/1.4.0/ontology/uco/observable/observable.ttl",
-    "https://raw.githubusercontent.com/ucoProject/UCO/1.4.0/ontology/uco/analysis/analysis.ttl",
+    "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/core/core.ttl",
+    "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/observable/observable.ttl",
+    "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/analysis/analysis.ttl",
 ]
 
 
@@ -150,8 +151,7 @@ class OntologyLookup:
         self._cache_dir.mkdir(parents=True, exist_ok=True)
 
         for url in urls:
-            filename = url.split("/")[-1]
-            cached_file = self._cache_dir / filename
+            cached_file = self._cache_dir / self._cache_name(url)
 
             # Try loading from cache first
             if cached_file.exists():
@@ -171,6 +171,17 @@ class OntologyLookup:
                 logger.debug(f"Loaded from URL: {url}")
             except Exception as e:
                 logger.warning(f"Failed to load remote module {url}: {e}")
+
+    @staticmethod
+    def _cache_name(url):
+        """Build the cache filename for a remote module URL.
+
+        Derived from the whole URL rather than its last segment. The same
+        filename occurs in every UCO release (observable.ttl and the rest), so a
+        name-only key returns whichever version was fetched first and a version
+        change has no effect until the cache is cleared by hand.
+        """
+        return re.sub(r"[^A-Za-z0-9._-]", "_", url.split("://", 1)[-1])
 
     @staticmethod
     def _download_file(url, dest):

--- a/solve_it_library/ontology_utils.py
+++ b/solve_it_library/ontology_utils.py
@@ -76,11 +76,16 @@ def _discover_solveit_ttl_files(base_api_url=SOLVEIT_ONTOLOGY_GITHUB_API):
         logger.warning(f"Could not discover SOLVE-IT TTL files from GitHub: {exc}")
         return None
 
-# UCO/CASE ontology module URLs for 1.5.0
+# UCO/CASE ontology module URLs for 1.5.0. The knowledge base references terms
+# from case-investigation (ProvenanceRecord, exhibitNumber) and uco-types (Hash),
+# so those modules are loaded too. CASE lays its repository out as
+# ontology/<module>/, without the extra path segment UCO uses.
 UCO_CASE_MODULES = [
     "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/core/core.ttl",
     "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/observable/observable.ttl",
     "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/analysis/analysis.ttl",
+    "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/types/types.ttl",
+    "https://raw.githubusercontent.com/casework/CASE/1.5.0/ontology/investigation/investigation.ttl",
 ]
 
 


### PR DESCRIPTION
**Draft — companion to SOLVE-IT-DF/solve-it-ontology#31. Merge that one first.**

UCO 1.5.0 defines `uco-action:Technique` as a metaclass whose instances are `owl:Class` entities that are subclasses of `uco-action:Action`. `solveit-core:Technique` now subclasses it, so the generated knowledge base has to emit each technique accordingly.

## `reporting_scripts/generate_rdf_from_kb.py`

- Each technique is now typed **both** `solveit-core:Technique` and `owl:Class`, so a performed investigative action can be typed with it directly.
- Each technique gets an `rdfs:subClassOf`: its parent technique where it has one, otherwise `solveit-core:SolveitInvestigativeAction`. This satisfies UCO's requirement that a Technique instance be a subclass of `uco-action:Action`, by way of `InvestigativeAction`. It must be asserted per technique because OWL 2 has no axiom meaning "instances of this metaclass are subclasses of X" — which is exactly why UCO states it as a convention in prose.
- Added `build_parent_map()`. The KB records the relationship in one direction only (a parent lists its subtechniques) and the metaclass model needs the reverse.
- CASE input/output classes emitted as `URIRef` rather than `xsd:anyURI` typed literals, matching the property change in the ontology.
- Every referenced input/output class is additionally declared `a owl:Class`. Without a declaration, an IRI in class position is a declaration error under OWL 2 DL. The declaration states only that the IRI names a class; it makes no claim about its definition.
- `hasSubtechnique` is still emitted unchanged, alongside the new `rdfs:subClassOf`.

## Verification

Run against the current knowledge base:

- 7,634 triples
- 191 techniques, all also `owl:Class`
- 160 root techniques + 31 sub-techniques, accounting for all 191
- zero non-IRI CASE class values
- UCO 1.5.0's own SHACL shapes validate the output with **zero violations and zero warnings**

## Merge order

The ontology repo's hourly `generate-knowledge-base` workflow checks out this repo at `ref: main`. Merging here switches the published KB to IRI-valued CASE classes straight away, so the ontology PR should land first to keep the schema ahead of the data.

## Downstream

SICL writes `solveit-core:usedTechnique` in its TTL and JSON-LD exports and will need updating separately. Its *reader* (`_get_list` in `sicl/models/knowledge_base.py`) already falls back to `@id` when `@value` is absent, so the literal → IRI change should not break it, though that was reasoned from the code rather than tested by running SICL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)