### PR TITLE
Record Explorer features and the Evaluate evidence objective in the c…

### DIFF
--- a/changelog/CHANGELOG_FEATURES.md
+++ b/changelog/CHANGELOG_FEATURES.md
@@ -2,6 +2,14 @@
 
 Describes features and tooling updates.
 
+### Git history and issue search from the Explorer (2026-07-06)
+
+Added two buttons to the detail panel of the HTML Explorer. "Show git history" opens the commit history of the JSON file that backs the item being viewed, so the sequence of changes to a technique, weakness or mitigation can be read directly. "Search git issue mentions" opens a GitHub issue search for the item's ID, covering both open and closed issues, so the discussion behind a change can be found from the item itself.
+
+### Drag and drop of techniques out of the Explorer (2026-06-20)
+
+Techniques in the HTML Explorer can now be dragged out of the page and dropped into another application open alongside it, including one running on a different origin. The drag carries the technique ID, which the receiving application uses to reconstruct the remaining detail from the knowledge base. Techniques can be dragged from the objective grid, from technique tables, and from the detail panel header.
+
 ### HTML viewer presentation mode (2026-04-16)
 
 Added a presentation view to the detail panel (technique only) for slide screenshots: a full-width two-column layout with weaknesses shown alongside their mitigations as a nested tree. Weakness and mitigation panels also gained hero and summary cards, mitigation counts now appear inline on weakness rows.

--- a/changelog/CHANGELOG_STRUCTURE.md
+++ b/changelog/CHANGELOG_STRUCTURE.md
@@ -2,6 +2,10 @@
 
 Changes to the knowledge base schema.
 
+### New objective: Evaluate evidence (2026-07-14)
+
+Added "Evaluate evidence" as a new objective, taking the knowledge base from 23 to 24 objectives. It sits between "Reconstruct events" and "Document digital forensic activities", and covers techniques concerned with assessing what the recovered material supports rather than recovering it. The objective was introduced alongside its first technique, Generate Alternative Hypotheses (DFT-1195). Anything consuming the objective list, including issue forms and generated views, reflects the additional entry.
+
 ### Weakness classes migration (2026-03-19)
 
 Migrated weakness ASTM error classification from 6 individual boolean-style fields (`INCOMP`, `INAC-EX`, etc.) to a single `categories` list field. Each class code is now prefixed with `ASTM_` (e.g. `ASTM_INCOMP`, `ASTM_INAC_EX`). 271 weakness files updated. Issue forms changed from checkboxes to textarea input. Ontology updated to use `hasWeaknessClass` object property with `ASTMErrorCategory` named individuals.


### PR DESCRIPTION
…hangelogs

The features changelog had recorded nothing since 2026-04-16 and the structure changelog nothing since 2026-03-19, so several user-visible changes were absent from the website, which builds these pages daily from this repo.

Features: the detail panel's git history and issue search buttons (2026-07-06) and drag and drop of techniques out of the Explorer (2026-06-20).

Structure: the new Evaluate evidence objective (2026-07-14), which took the knowledge base from 23 to 24 objectives.