### PR TITLE
Keyword searches output a KeywordSearchResultSet, not a single result

### DIFF
--- a/data/techniques/DFT-1049.json
+++ b/data/techniques/DFT-1049.json
@@ -24,7 +24,7 @@
     ],
     "CASE_input_classes": [],
     "CASE_output_classes": [
-        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResult"
+        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResultSet"
     ],
     "references": [
         {

--- a/data/techniques/DFT-1122.json
+++ b/data/techniques/DFT-1122.json
@@ -14,7 +14,7 @@
     ],
     "CASE_input_classes": [],
     "CASE_output_classes": [
-        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResult"
+        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResultSet"
     ],
     "references": [
         {

--- a/data/techniques/DFT-1123.json
+++ b/data/techniques/DFT-1123.json
@@ -12,7 +12,7 @@
     ],
     "CASE_input_classes": [],
     "CASE_output_classes": [
-        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResult"
+        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResultSet"
     ],
     "references": []
 }

--- a/data/techniques/DFT-1125.json
+++ b/data/techniques/DFT-1125.json
@@ -14,7 +14,7 @@
     ],
     "CASE_input_classes": [],
     "CASE_output_classes": [
-        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResult"
+        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResultSet"
     ],
     "references": [
         {

--- a/data/techniques/DFT-1126.json
+++ b/data/techniques/DFT-1126.json
@@ -16,7 +16,7 @@
     ],
     "CASE_input_classes": [],
     "CASE_output_classes": [
-        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResult"
+        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResultSet"
     ],
     "references": [
         {

--- a/data/techniques/DFT-1127.json
+++ b/data/techniques/DFT-1127.json
@@ -14,7 +14,7 @@
     ],
     "CASE_input_classes": [],
     "CASE_output_classes": [
-        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResult"
+        "https://ontology.solveit-df.org/solveit/observable/KeywordSearchResultSet"
     ],
     "references": [
         {


### PR DESCRIPTION
Six keyword search techniques declared KeywordSearchResult as their output class. The ontology models the two as a container and its contents: KeywordSearchResultSet is the domain of solveit-observable:hasSearchResult and KeywordSearchResult is its range, so a search produces the set, which holds the individual results.

DFT-1124 (Keyword search (indexed)) already declared KeywordSearchResultSet, so the seven keyword search techniques disagreed with each other as well as with the ontology. This brings the other six into line:

  DFT-1049  Keyword search                          (parent technique)
  DFT-1122  Keyword search (case-type wordlists)
  DFT-1123  Keyword search (case-specific wordlists)
  DFT-1125  Keyword search (live)
  DFT-1126  Keyword search (live) (physical)
  DFT-1127  Keyword search (live) (logical)

Found through the ontology repository's example I/O validation, where four example actions produced a KeywordSearchResultSet against techniques that declared the singular form.

Verified: validate_kb.py --check-ontology passes 41 checks, 0 failures, 409 warnings unchanged, and KeywordSearchResultSet resolves in the loaded ontologies. Regenerating the knowledge base and running the ontology repository's validate_examples.py against it clears all four mismatches, taking it from 11 to 7; the remainder are the timeline and disk acquisition cases, which are separate questions.