### PR TITLE
Declare input and output terms with the type they actually have

### DIFF
--- a/admin/validate_kb.py
+++ b/admin/validate_kb.py
@@ -26,7 +26,9 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from pydantic import ValidationError
 from solve_it_library.models import Technique, Weakness, Mitigation, Objective, CitationFiles
 from solve_it_library.citation_utils import find_inline_citations
-from solve_it_library.ontology_utils import OntologyLookup, SOLVEIT_ONTOLOGY_DEFAULT_URL
+from solve_it_library.ontology_utils import (
+    OntologyLookup, SOLVEIT_ONTOLOGY_DEFAULT_URL, EXTRA_UCO_MODULES,
+    get_projectvic_ttl_urls)
 
 
 # ── Output helpers ────────────────────────────────────────────────────────────
@@ -565,34 +567,6 @@ KNOWN_PREFIXES = [
 URL_PATTERN = re.compile(r"^https?://")
 
 
-PROJECTVIC_ONTOLOGY_BASE = (
-    "https://raw.githubusercontent.com/Project-VIC-International/CAC-Ontology/main/ontology/"
-)
-
-
-def _get_projectvic_ttl_urls() -> List[str]:
-    """Fetch the list of non-shape TTL files from the ProjectVic CAC-Ontology repo."""
-    api_url = "https://api.github.com/repos/Project-VIC-International/CAC-Ontology/contents/ontology"
-    try:
-        try:
-            import requests
-            resp = requests.get(api_url, headers={"Accept": "application/vnd.github.v3+json"}, timeout=15)
-            resp.raise_for_status()
-            entries = resp.json()
-        except ImportError:
-            import urllib.request
-            req = urllib.request.Request(api_url, headers={"Accept": "application/vnd.github.v3+json"})
-            with urllib.request.urlopen(req, timeout=15) as resp:
-                entries = json.loads(resp.read())
-        return [
-            PROJECTVIC_ONTOLOGY_BASE + e["name"]
-            for e in entries
-            if e["name"].endswith(".ttl") and "shapes" not in e["name"]
-        ]
-    except Exception:
-        return []
-
-
 def phase4_case_urls(techniques: Dict, result: ValidationResult, verbose: bool,
                      check_ontology: bool = False) -> List[str]:
     """Validate CASE/UCO class URLs. Returns list of ontology IRI mismatch messages."""
@@ -625,15 +599,10 @@ def phase4_case_urls(techniques: Dict, result: ValidationResult, verbose: bool,
             load_case_uco=True,
         )
         # Load additional UCO modules referenced by the KB
-        extra_modules = [
-            "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/configuration/configuration.ttl",
-            "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/identity/identity.ttl",
-            "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/location/location.ttl",
-        ]
-        lookup._load_remote_modules(extra_modules)
+        lookup._load_remote_modules(EXTRA_UCO_MODULES)
 
         # Load all ProjectVic CAC Ontology modules (excluding SHACL shapes)
-        projectvic_modules = _get_projectvic_ttl_urls()
+        projectvic_modules = get_projectvic_ttl_urls()
         if projectvic_modules:
             lookup._load_remote_modules(projectvic_modules)
         else:

--- a/admin/validate_kb.py
+++ b/admin/validate_kb.py
@@ -648,7 +648,13 @@ def phase4_case_urls(techniques: Dict, result: ValidationResult, verbose: bool,
             for url in t.get(field_name, []):
                 desc = lookup.describe_class(url)
                 if not desc["found"]:
-                    msg = f"Technique {tid} {field_name}: \"{url}\" not found in loaded ontologies"
+                    if desc.get("present"):
+                        msg = (
+                            f"Technique {tid} {field_name}: \"{url}\" is in the loaded "
+                            f"ontologies but is not a class or property"
+                        )
+                    else:
+                        msg = f"Technique {tid} {field_name}: \"{url}\" not found in loaded ontologies"
                     result.warn(msg)
                     ontology_issues.append(msg)
                     bad += 1
@@ -942,6 +948,7 @@ WARNING_CATEGORIES = [
     ("Todo markers", "contains todo marker"),
     ("Not in any objective", "is not listed in any objective"),
     ("Ontology IRI not found", "not found in loaded ontologies"),
+    ("Ontology IRI not a class or property", "is not a class or property"),
     ("Empty relevance summary", "has empty relevance_summary"),
 ]
 

--- a/reporting_scripts/generate_rdf_from_kb.py
+++ b/reporting_scripts/generate_rdf_from_kb.py
@@ -119,6 +119,30 @@ def build_parent_map(kb, techniques):
     return parents
 
 
+def load_term_type_lookup():
+    """Load the ontologies used to state what kind of term each input/output is.
+
+    Returns None if they cannot be loaded. The generator then emits no type
+    declarations at all rather than guessing, because a wrong declaration is
+    worse than an absent one: it is the assertion a consumer would trust.
+    """
+    try:
+        from solve_it_library.ontology_utils import (
+            OntologyLookup, SOLVEIT_ONTOLOGY_DEFAULT_URL, EXTRA_UCO_MODULES,
+            get_projectvic_ttl_urls)
+        lookup = OntologyLookup(
+            solve_it_ontology_url=SOLVEIT_ONTOLOGY_DEFAULT_URL,
+            load_case_uco=True,
+        )
+        lookup._load_remote_modules(EXTRA_UCO_MODULES + get_projectvic_ttl_urls())
+        return lookup
+    except Exception as exc:  # network, parse, anything
+        logger.warning(
+            "Could not load ontologies to determine input/output term types "
+            "(%s). Terms will be referenced without a type declaration.", exc)
+        return None
+
+
 def add_techniques_to_graph(g, kb):
     """Add all techniques to the RDF graph.
 
@@ -208,12 +232,29 @@ def add_techniques_to_graph(g, kb):
             g.add((tech_uri, SOLVEIT_CORE.hasCASEOutputClass, URIRef(case_class_uri)))
             referenced_classes.add(case_class_uri)
 
-    # Declare every referenced input/output class as an owl:Class. Without a
-    # declaration, an IRI used in class position is a declaration error under
-    # OWL 2 DL. This states only that the IRI names a class, which is what the
-    # KB is asserting anyway; it makes no claim about the class's definition.
-    for class_uri in sorted(referenced_classes):
-        g.add((URIRef(class_uri), RDF.type, OWL.Class))
+    # Declare every referenced input/output term with the type it actually has
+    # in CASE/UCO. Most are classes, but a technique can consume or produce a
+    # single value rather than an object, and then the term is a property:
+    # case-investigation:exhibitNumber, uco-core:name, uco-observable:filePath.
+    # Declaring those an owl:Class stated something false about them, which is
+    # the assertion a consumer would trust. A term whose type cannot be
+    # resolved is referenced without a declaration rather than guessed at.
+    lookup = load_term_type_lookup()
+    if lookup is not None:
+        counts, unresolved = {}, []
+        for class_uri in sorted(referenced_classes):
+            term_type = lookup.term_type(class_uri)
+            if term_type is None:
+                unresolved.append(class_uri)
+                continue
+            g.add((URIRef(class_uri), RDF.type, term_type))
+            counts[str(term_type).rsplit("#", 1)[-1]] = counts.get(
+                str(term_type).rsplit("#", 1)[-1], 0) + 1
+        logger.info("Declared %d input/output terms: %s",
+                    sum(counts.values()),
+                    ", ".join(f"{n} {k}" for k, n in sorted(counts.items())))
+        for term in unresolved:
+            logger.warning("Input/output term not declared, type unresolved: %s", term)
 
 
 def add_weaknesses_to_graph(g, kb):

--- a/solve_it_library/ontology_utils.py
+++ b/solve_it_library/ontology_utils.py
@@ -88,6 +88,14 @@ UCO_CASE_MODULES = [
     "https://raw.githubusercontent.com/casework/CASE/1.5.0/ontology/investigation/investigation.ttl",
 ]
 
+# The kinds of ontology term a technique may name among its inputs and outputs.
+# Classes are the common case, but properties are also legitimate: a technique
+# can produce a single value rather than an object, for example
+# case-investigation:exhibitNumber or uco-core:name. Anything else that happens
+# to appear in a loaded ontology, such as a SHACL shape, a named individual or a
+# vocabulary entry, is not a valid input or output.
+ACCEPTED_TERM_TYPES = (OWL.Class, OWL.DatatypeProperty, OWL.ObjectProperty)
+
 
 class OntologyLookup:
     """Loads ontology files and provides class description lookups."""
@@ -242,15 +250,21 @@ class OntologyLookup:
             "data_properties": [],
             "comment": None,
             "found": False,
+            "present": False,
         }
 
-        # Check if the class exists in the ontology
-        is_class = (uri, RDF.type, OWL.Class) in self.graph
-        has_any_triple = any(self.graph.triples((uri, None, None)))
-        if not is_class and not has_any_triple:
+        # Accept the IRI only if it is declared as one of the term types a
+        # technique may name. Testing the declared type rather than the mere
+        # presence of a triple means a term that resolves but is the wrong kind
+        # of thing is still reported, and is distinguished from one that is
+        # absent from the loaded ontologies altogether.
+        if any((uri, RDF.type, t) in self.graph for t in ACCEPTED_TERM_TYPES):
+            result["found"] = True
+        else:
+            result["present"] = any(self.graph.triples((uri, None, None)))
             return result
 
-        result["found"] = True
+        result["present"] = True
 
         # Get rdfs:comment
         for comment in self.graph.objects(uri, RDFS.comment):

--- a/solve_it_library/ontology_utils.py
+++ b/solve_it_library/ontology_utils.py
@@ -88,6 +88,48 @@ UCO_CASE_MODULES = [
     "https://raw.githubusercontent.com/casework/CASE/1.5.0/ontology/investigation/investigation.ttl",
 ]
 
+# UCO modules beyond the default set that the knowledge base draws terms from.
+EXTRA_UCO_MODULES = [
+    "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/configuration/configuration.ttl",
+    "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/identity/identity.ttl",
+    "https://raw.githubusercontent.com/ucoProject/UCO/1.5.0/ontology/uco/location/location.ttl",
+]
+
+PROJECTVIC_ONTOLOGY_BASE = (
+    "https://raw.githubusercontent.com/Project-VIC-International/CAC-Ontology/main/ontology/"
+)
+
+
+def get_projectvic_ttl_urls():
+    """Fetch the list of non-shape TTL files from the ProjectVic CAC-Ontology repo.
+
+    The knowledge base references ProjectVic terms, so anything that needs to
+    resolve a technique's inputs and outputs needs these alongside UCO and CASE.
+    Returns an empty list if the listing cannot be fetched, leaving the caller
+    to decide what an unresolved term means.
+    """
+    api_url = "https://api.github.com/repos/Project-VIC-International/CAC-Ontology/contents/ontology"
+    try:
+        try:
+            import requests
+            resp = requests.get(
+                api_url, headers={"Accept": "application/vnd.github.v3+json"}, timeout=15)
+            resp.raise_for_status()
+            entries = resp.json()
+        except ImportError:
+            req = urllib.request.Request(
+                api_url, headers={"Accept": "application/vnd.github.v3+json"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                entries = json.loads(resp.read())
+        return [
+            PROJECTVIC_ONTOLOGY_BASE + e["name"]
+            for e in entries
+            if e["name"].endswith(".ttl") and "shapes" not in e["name"]
+        ]
+    except Exception:
+        return []
+
+
 # The kinds of ontology term a technique may name among its inputs and outputs.
 # Classes are the common case, but properties are also legitimate: a technique
 # can produce a single value rather than an object, for example
@@ -227,6 +269,21 @@ class OntologyLookup:
             return uri_str.split("#")[-1]
         # Otherwise use the last path segment
         return uri_str.split("/")[-1]
+
+    def term_type(self, uri):
+        """Return the declared type of a term, or None if it is not one we accept.
+
+        Answers "is this IRI a class, a datatype property or an object
+        property?" for callers that need to state a term's kind rather than
+        merely check that it is valid. Returns the URIRef of the declared type
+        so a caller can assert it directly.
+        """
+        if not isinstance(uri, URIRef):
+            uri = URIRef(uri)
+        for term_type in ACCEPTED_TERM_TYPES:
+            if (uri, RDF.type, term_type) in self.graph:
+                return term_type
+        return None
 
     def describe_class(self, class_uri):
         """


### PR DESCRIPTION
**Companion to SOLVE-IT-DF/solve-it-ontology#37. Merge that one first** — it removes the `owl:Class` range this change stops satisfying. Merging here first publishes data the schema still rejects, and the hourly `generate-knowledge-base` and `generate-data` jobs pick it up within the hour.

`generate_rdf_from_kb.py` declared every referenced input and output term an `owl:Class`. Of the 173 terms the knowledge base references, **42 are properties** — 33 datatype and 9 object — because a technique can consume or produce a single value rather than an object: `case-investigation:exhibitNumber`, `uco-core:name`, `uco-observable:filePath`.

So the published knowledge base asserts `uco-observable:fileName a owl:Class` where UCO declares it a datatype property. To be precise: this is **not** an OWL 2 DL violation — the profile forbids an IRI being two kinds of property, or a class and a datatype, but not a class and a property. It is simply false, and it is the assertion a consumer would trust.

## The change

The generator resolves each term against the ontologies and asserts the type it finds:

```
INFO: Declared 173 input/output terms: 131 Class, 33 DatatypeProperty, 9 ObjectProperty
```

It loads UCO, CASE, SOLVE-IT and ProjectVic — what the knowledge base actually draws terms from. Adding ProjectVic is what takes the unresolved count to zero: `DFT-1093` names a ProjectVic term, and `admin/validate_kb.py` already fetched that ontology while the generator did not.

**If the ontologies cannot be loaded it emits no declarations at all** rather than guessing. A wrong declaration is worse than an absent one.

## `ontology_utils.py`

- adds `term_type()`, returning a term's declared type so a caller can assert it rather than merely check it
- `EXTRA_UCO_MODULES` and the ProjectVic module discovery move here from `admin/validate_kb.py`. Both the validator and the generator need them, and they belong with the loading rather than in one caller. `validate_kb.py` now imports them instead of holding its own copy.

## Also in this PR

The first commit, "Accept classes and properties as technique inputs and outputs, and nothing else", was written on 6 August and never pushed. It is the design position this change implements — that properties are legitimate technique inputs and outputs — so it belongs here rather than stranded on a local branch. It tightens the IRI check to accept only `owl:Class`, `owl:DatatypeProperty` and `owl:ObjectProperty`, rejecting the 23 SHACL shape IRIs that previously passed.

## Verification

- 7,634 triples, unchanged
- `validate_kb.py --check-ontology`: 41 checks passed, 0 failed, 409 warnings — all unchanged
- against the new `TechniqueIOTermConsistencyShape` in #37, with UCO 1.5.0 and CASE 1.5.0 loaded: the knowledge base as published today gives **56 violations across those 42 terms**; this output gives **0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
