### PR TITLE
CASE/CAC IRI failures must fail, not only warn

### DIFF
--- a/admin/validate_kb.py
+++ b/admin/validate_kb.py
@@ -575,10 +575,10 @@ def phase4_case_urls(techniques: Dict, result: ValidationResult, verbose: bool,
         for field_name in ("CASE_input_classes", "CASE_output_classes"):
             for url in t.get(field_name, []):
                 if not URL_PATTERN.match(url):
-                    result.warn(f"Technique {tid} {field_name}: \"{url}\" is not a valid URL")
+                    result.fail(f"Technique {tid} {field_name}: \"{url}\" is not a valid URL")
                     bad += 1
                 elif not any(url.startswith(prefix) for prefix in KNOWN_PREFIXES):
-                    result.warn(
+                    result.fail(
                         f"Technique {tid} {field_name}: \"{url}\" does not match "
                         f"any known ontology prefix"
                     )
@@ -624,7 +624,7 @@ def phase4_case_urls(techniques: Dict, result: ValidationResult, verbose: bool,
                         )
                     else:
                         msg = f"Technique {tid} {field_name}: \"{url}\" not found in loaded ontologies"
-                    result.warn(msg)
+                    result.fail(msg)
                     ontology_issues.append(msg)
                     bad += 1
     if bad == 0:
@@ -1124,7 +1124,7 @@ def _write_ontology_summary(ontology_issues: List[str], filepath: str):
             f"**{len(ontology_issues)} class IRI(s) not found** in the loaded ontologies.",
             "",
             "These IRIs may have been renamed, removed, or not yet published. "
-            "This does not block the build but should be investigated.",
+            "This fails the build.",
             "",
         ]
         for msg in ontology_issues:


### PR DESCRIPTION
`phase4_case_urls` only `result.warn`s when a CASE/CAC IRI is a non-URL, an unknown prefix, or missing from the loaded ontologies. `ValidationResult.ok` ignores warnings, so those IRI problems cannot turn the job red.

This packet changes those three IRI calls to `result.fail`. Completeness warnings in phase 5 stay warnings. Load-failure warnings in phase 4 stay warnings. `ValidationResult.ok` is unchanged.

## Files

1. `admin/validate_kb.py` — three `result.warn` → `result.fail` in `phase4_case_urls`, plus the ontology-summary sentence so it no longer says the build stays green.

## Out of scope

- Failing every warn in this validator
- Phase 5 completeness
- `#563` pytest rename
- `tests/library_unit_tests.py` / `tests/test_library_unit_tests.py`

## How to review

The dest is those three IRI calls. A bad CASE/CAC IRI should print `[FAIL]` and `result.ok` should be false. A missing technique description should still print `[WARN]` and leave `result.ok` true.

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes.
